### PR TITLE
chore (components) : replaced "Goolge" to "Google"

### DIFF
--- a/components/user-auth-form.tsx
+++ b/components/user-auth-form.tsx
@@ -115,7 +115,7 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
           ) : (
             <Icons.google className="mr-2 h-4 w-4" />
           )}{" "}
-          Goolge
+          Google
         </Button>
       </div>
     </>


### PR DESCRIPTION
### The button for Google login, in the login page was spelled wrong. I changed the spelling from "<b><i>Goolge</i></b>" to "<b><i>Google</i></b>".  (markdx/components/user-auth-form.tsx) (line 118).
![Screenshot 2025-02-05 222236](https://github.com/user-attachments/assets/57f81aa6-c8d9-413a-9bc2-e4bc3253feba)